### PR TITLE
fix: render `command` variable into `setup.py` only if package `$.install.hooks` is used

### DIFF
--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -23,3 +23,9 @@ changes:
   description: '`pylint` now comes with `.pylintrc` templates (only `shut` for now)
     and can also render templates from HTTP(S) URLs'
   fixes: []
+- type: fix
+  component: general
+  description: render `command` variable into `setup.py` only if package `$.install.hooks`
+    is used
+  fixes:
+  - '#33'

--- a/package.yml
+++ b/package.yml
@@ -49,10 +49,6 @@ package-data:
 - include: data/pylintrc_templates/*.ini
 test-drivers:
 - type: mypy
-- type: pylint
-  rcfile:
-    template: shut
-    #render: true
 - type: pytest
 publish:
   pypi:

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,6 @@ import os
 import setuptools
 import sys
 
-command = sys.argv[1] if len(sys.argv) >= 2 else None
-
 readme_file = 'README.md'
 if os.path.isfile(readme_file):
   with io.open(readme_file, encoding='utf8') as fp:

--- a/src/shut/renderers/setuptools.py
+++ b/src/shut/renderers/setuptools.py
@@ -115,13 +115,12 @@ class SetuptoolsRenderer(Renderer[PackageModel]):
       import os
       import setuptools
       import sys
-
-      command = sys.argv[1] if len(sys.argv) >= 2 else None
     ''').lstrip())
 
     # Write hook overrides.
     cmdclass = {}
     if install.hooks.any():
+      fp.write('\ncommand = sys.argv[1] if len(sys.argv) >= 2 else None')
       fp.write('\ninstall_hooks = {}\n'.format(json.dumps(install.hooks.as_payload(), indent=2)))
       fp.write(textwrap.dedent('''
         def _run_hooks(event):


### PR DESCRIPTION

fixes #33