### PR TITLE
nr/fix 81

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,6 +3,7 @@ id = "1326c953-8cd4-486d-8a5e-a78f7e3d045c"
 type = "fix"
 description = "Dependency with extras are now written correctly into `pyprojec.toml` for Poetry projects"
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/slap/pull/84"
 issues = [
     "https://github.com/NiklasRosenstein/slap/issues/81",
 ]

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,8 @@
+[[entries]]
+id = "1326c953-8cd4-486d-8a5e-a78f7e3d045c"
+type = "fix"
+description = "Dependency with extras are now written correctly into `pyprojec.toml` for Poetry projects"
+author = "@NiklasRosenstein"
+issues = [
+    "https://github.com/NiklasRosenstein/slap/issues/81",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,10 @@ types-PyYAML = "^6.0.3"
 types-requests = "^2.27.7"
 types-termcolor = "^1.1.3"
 
-[tool.poetry.groups.docs]
+[tool.poetry.group.docs]
 optional = true
 
-[tool.poetry.groups.docs.dependencies]
+[tool.poetry.group.docs.dependencies]
 mkdocs = "*"
 mkdocs-material = "*"
 novella = "0.2.3"

--- a/src/slap/ext/project_handlers/poetry.py
+++ b/src/slap/ext/project_handlers/poetry.py
@@ -133,7 +133,7 @@ def convert_dependency_to_poetry_config(dependency: Dependency) -> t.Mapping[str
     from slap.python.dependency import PypiDependency
 
     if isinstance(dependency, PypiDependency):
-        if not dependency.markers and not dependency.python and not dependency.source:
+        if not dependency.markers and not dependency.python and not dependency.source and not dependency.extras:
             return str(dependency.version)
         result = tomlkit.api.inline_table()
         result["version"] = str(dependency.version)


### PR DESCRIPTION
- fix pyproject.toml
- fix: Dependency with extras are now written correctly into `pyprojec.toml` for Poetry projects
