### PR TITLE
Allow passing `none`/`null` to `slap init --license` and automatically upgrade Pip on`slap venv --create` unless `--no-upgrade-pip` is given

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,12 @@ id = "dcd60d11-3358-422d-a86a-474795372cd8"
 type = "improvement"
 description = "allow passing `none` or `null` for the `slap init --license` parameter"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "af82da0c-1c32-45e0-a28d-534a17c63ea6"
+type = "feature"
+description = "Add `slap venv --no-upgrade-pip` option and automatically upgrade Pip after creating a virtual environment if the option is not specified."
+author = "@NiklasRosenstein"
+issues = [
+    "https://github.com/NiklasRosenstein/slap/issues/102",
+]

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,12 +3,14 @@ id = "dcd60d11-3358-422d-a86a-474795372cd8"
 type = "improvement"
 description = "allow passing `none` or `null` for the `slap init --license` parameter"
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/slap/pull/103"
 
 [[entries]]
 id = "af82da0c-1c32-45e0-a28d-534a17c63ea6"
 type = "feature"
 description = "Add `slap venv --no-upgrade-pip` option and automatically upgrade Pip after creating a virtual environment if the option is not specified."
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/slap/pull/103"
 issues = [
     "https://github.com/NiklasRosenstein/slap/issues/102",
 ]

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "dcd60d11-3358-422d-a86a-474795372cd8"
+type = "improvement"
+description = "allow passing `none` or `null` for the `slap init --license` parameter"
+author = "@NiklasRosenstein"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.x"]
+        python-version: ["3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.x"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ Homepage = "https://github.com/NiklasRosenstein/slap"
 Repository = "https://github.com/NiklasRosenstein/slap.git"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = ">=3.10,<3.12"
 beautifulsoup4 = "^4.10.0"
 cleo = ">=1.0.0a4"
 "databind" = "^4.4.0"

--- a/src/slap/ext/application/init.py
+++ b/src/slap/ext/application/init.py
@@ -126,6 +126,8 @@ class InitCommandPlugin(Command, ApplicationPlugin):
             )
         for filename, content in load_template(template):
             if filename == "LICENSE":
+                if self.option("license") in ("null", "none"):
+                    continue
                 content = get_spdx_license_details(self.option("license")).license_text
                 content = wrap_license_text(content).replace("<year>", str(scope["year"]))
                 content = wrap_license_text(content).replace("<copyright holders>", scope["author_name"])

--- a/src/slap/ext/application/venv.py
+++ b/src/slap/ext/application/venv.py
@@ -256,6 +256,7 @@ class VenvCommand(Command):
             description="Create the environment with the given environment name. If no <opt>name</opt> is specified, "
             "the environment name will be the major.minor version of the current Python version.",
         ),
+        option("--no-upgrade-pip", description="If specified, will not upgrade Pip after creating a new environment."),
         option(
             "--delete",
             "-d",
@@ -325,6 +326,11 @@ class VenvCommand(Command):
                 if self.option(opt):
                     self.line_error("error: <opt>--path,-P</opt> is not compatible with <opt>--{opt}</opt>", "error")
                     return False
+        if self.option("no-upgrade-pip") and not self.option("create"):
+            self.line_error(
+                "error: <opt>--no-pip-upgrade</opt> is only valid in combination with <opt>-c,--create</opt>"
+            )
+            return False
         if not any(
             self.option(opt) for opt in ("activate", "create", "delete", "set", "list", "init-code", "path", "exists")
         ):
@@ -411,6 +417,10 @@ class VenvCommand(Command):
                 f'creating {location} environment <s>"{venv.name}"</s> (using <code>{python}</code>)', "info"
             )
             venv.create(python)
+
+            if not self.option("no-upgrade-pip"):
+                self.line_error("upgrading Pip to the latest version", "info")
+                sp.check_call([str(venv.get_bin("pip")), "install", "-U", "pip"])
 
         if self.option("activate"):
             if not venv:


### PR DESCRIPTION
- improvement: allow passing `none` or `null` for the `slap init --license` parameter
- feature: Add `slap venv --no-upgrade-pip` option and automatically upgrade Pip after creating a virtual environment if the option is not specified.
